### PR TITLE
feat: skydda skrivande /places-endpoints med API-nyckel och standardi…

### DIFF
--- a/src/main/java/com/grupp3/weather/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/grupp3/weather/config/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.grupp3.weather.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleBadRequest(IllegalArgumentException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", "Bad Request");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        var errors = ex.getBindingResult().getAllErrors();
+        var msg = errors.isEmpty() ? "Validation failed" : errors.get(0).getDefaultMessage();
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", "Validation failed");
+        body.put("message", msg);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", ex.getStatusCode().toString());
+        body.put("message", ex.getReason());
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
+    }
+}

--- a/src/main/java/com/grupp3/weather/config/SecurityConfig.java
+++ b/src/main/java/com/grupp3/weather/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.grupp3.weather.config;
+
+import com.grupp3.weather.security.ApiKeyFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilterRegistration(ApiKeyFilter filter) {
+        FilterRegistrationBean<ApiKeyFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(filter);
+        reg.addUrlPatterns("/*");                     // körs på alla endpoints
+        reg.setOrder(Ordered.HIGHEST_PRECEDENCE);     // tidigt i kedjan
+        return reg;
+    }
+}

--- a/src/main/java/com/grupp3/weather/security/ApiKeyFilter.java
+++ b/src/main/java/com/grupp3/weather/security/ApiKeyFilter.java
@@ -1,0 +1,38 @@
+package com.grupp3.weather.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    @Value("${app.api-key}")
+    private String expected;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        // Läsning (GET) tillåts utan nyckel, skrivning kräver nyckel
+        boolean isWrite = !HttpMethod.GET.matches(req.getMethod());
+
+        if (isWrite) {
+            String provided = req.getHeader("X-API-KEY");
+            if (provided == null || !provided.equals(expected)) {
+                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                return;
+            }
+        }
+
+        chain.doFilter(req, res);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@ spring.application.name=weather-api
 
 # StÃ¤ng av automatisk databaskonfiguration (vi kÃ¶r utan DB just nu)
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+# src/main/resources/application.properties
+app.api-key=topsecret123


### PR DESCRIPTION
…sera JSON-fel

• Inför enkel header-baserad API-nyckelkontroll (X-API-KEY) för POST/PUT/DELETE på /places. • Returnerar nu konsekventa JSON-fel (400, 401, 404, 409) istället för tomma svar. • Validering: kräver name + lat + lon; dubbletter ger 409. • Uppdaterade controller-kommentarer och mindre städning.